### PR TITLE
Add requirements.txt and convert to pip-installable version of python-magic

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,5 @@ Grabs the text of the book UNSONG by Scott Alexander from [unsongbook.com](http:
 
 Requires Python 3 and PIL. Creates a folder `cache` which caches the downloaded text and images so it can be re-run again later and be a lot quicker. Requires Calibre's `ebook-convert` to actually do the conversion to epub.
 
+Install python requirements with `pip install -r requirements.txt`
 Run `bash create_unsong_book.sh`, which will output `Unsong.epub`.

--- a/create_unsong_book.sh
+++ b/create_unsong_book.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+mkdir -p cache
+
 echo Fetching book
 python3 get_unsong.py $*
 

--- a/get_unsong.py
+++ b/get_unsong.py
@@ -192,10 +192,8 @@ def get_url(url):
     for img in content.find_all("img"):
         img_url = img["src"]
         img_data = fetch_or_get(img_url, binary=True)
-        magic_identifier = magic.open(magic.MIME)
-        magic_identifier.load()
-        img_type = magic_identifier.buffer(img_data)
-        magic_identifier.close()
+        magic_identifier = magic.Magic(mime=True)
+        img_type = magic_identifier.from_buffer(img_data)
         img_type = img_type.split(";")[0]
 
         img["src"] = "data:%s;base64,%s" % (img_type, base64.encodestring(img_data).decode("utf-8"))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+python-magic==0.4.13
+lxml==3.8.0
+beautifulsoup4==4.6.0
+Pillow==4.2.1


### PR DESCRIPTION
I ran into some issues running this script and have a few suggested fixes to make it easier for others who come across it

- Add a requirements.txt that lists out dependencies. Without this one has to manually iterate through running the script and install missing deps in a loop. Instead, tell users to just pip -r requirements.txt
- Convert calls to python-magic to use the [pip installable version](https://pypi.python.org/pypi/python-magic/0.4.13). I spent a half hour trying to figure out how to install the version used by this script on a mac without success - all that's out there are references to people failing to have it... Since this is such an easy and quick conversion, I suggest using the more common one which also allows requirements.txt to be complete
- Create the cache directory in the shell script (the script fails with a stacktrace without it. Alternatively, we can add this to the python script)