### PR TITLE
specify encoding when opening file

### DIFF
--- a/lcs.py
+++ b/lcs.py
@@ -19,7 +19,7 @@ import re
 import difflib
 
 def load_soup():
-    fp = open("Unsong.html")
+    fp = open("Unsong.html", encoding='utf8')
     data = fp.read()
     fp.close()
     soup = BeautifulSoup(data, "lxml")


### PR DESCRIPTION
When encoding='utf8' is not specified, I get an error when trying to run this script on Windows. When encoding='utf8' is specified, the error goes away.